### PR TITLE
Add "=" strand support

### DIFF
--- a/snapgene_reader/snapgene_reader.py
+++ b/snapgene_reader/snapgene_reader.py
@@ -217,7 +217,7 @@ def snapgene_file_to_seqrecord(filepath=None, fileobject=None):
         SnapGene.
     """
     data = snapgene_file_to_dict(filepath=filepath, fileobject=fileobject)
-    strand_dict = {"+": 1, "-": -1, ".": 0}
+    strand_dict = {"+": 1, "-": -1, ".": 0, "=": 0}
 
     if has_dna_alphabet:
         seq = Seq(data["seq"], alphabet=DNAAlphabet())


### PR DESCRIPTION
The `snapgene_file_to_dict()` function may return a strand value equal to "=" (line 134) causing an exception to be raised by `snapgene_file_to_seqrecord()`(line 220). 

In SnapGene this value corresponds to the "bidirectional" strand option.