### PR TITLE
changed variable name filepath to file_path in README.rst

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pytest pytest-cov coveralls
+      - name: Install
+        run: |
+          pip install -e .
+      - name: Test with pytest
+        run: |
+          python -m pytest --cov snapgene_reader --cov-report term-missing
+      - name: Coveralls
+        run: coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COVERALLS_SERVICE_NAME: github

--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ SnapGene Reader is a Python library to parse Snapgene ``*.dna`` files into dicti
   from snapgene_reader import snapgene_file_to_dict, snapgene_file_to_seqrecord
 
   file_path = './snap_gene_file.dna'
-  dictionary = snapgene_file_to_dict(filepath)
-  seqrecord = snapgene_file_to_seqrecord(filepath)
+  dictionary = snapgene_file_to_dict(file_path)
+  seqrecord = snapgene_file_to_seqrecord(file_path)
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 SnapGene Reader
 ===============
 
-.. image:: https://travis-ci.org/Edinburgh-Genome-Foundry/SnapGeneReader.svg?branch=master
-   :target: https://travis-ci.org/Edinburgh-Genome-Foundry/SnapGeneReader
+.. image:: https://github.com/Edinburgh-Genome-Foundry/Flametree/actions/workflows/build.yml/badge.svg
+   :target: https://github.com/Edinburgh-Genome-Foundry/Flametree/actions/workflows/build.yml
    :alt: Travis CI build status
 
 .. image:: https://coveralls.io/repos/github/Edinburgh-Genome-Foundry/SnapGeneReader/badge.svg?branch=master
@@ -32,8 +32,8 @@ Test with Pytest:
 
 .. code:: bash
 
-    python -m pytest
-    # or simply "pytest"
+    pytest --cov=snapgene_reader tests/
+
 
 Licence = MIT
 -------------

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="snapgene_reader",
-    version="0.1.19",
+    version="0.1.20",
     author="yishaluo",
     maintainer="EdinburghGenomeFoundry",
     description="Convert Snapgene *.dna files dict/json/biopython.",


### PR DESCRIPTION
In readme file the variable file_path is defined as:
```
file_path = './snap_gene_file.dna'
```
But while passing that variable as an argument into the function snapgene_file_to_dict and snapgene_file_to_seqrecord it is misnamed as filepath:
```
dictionnary = snapgene_file_to_dict(filepath)
seqrecord = snapgene_file_to_seqrecord(filepath)
```


Thus the above two lines have been updated to:
```
dictionnary = snapgene_file_to_dict(file_path)
seqrecord = snapgene_file_to_seqrecord(file_path)
```