### PR TITLE
Fix seqfeature strand arg

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,8 +16,8 @@ SnapGene Reader is a Python library to parse Snapgene ``*.dna`` files into dicti
   from snapgene_reader import snapgene_file_to_dict, snapgene_file_to_seqrecord
 
   file_path = './snap_gene_file.dna'
-  dictionary = snapgene_file_to_dict(filepath)
-  seqrecord = snapgene_file_to_seqrecord(filepath)
+  dictionary = snapgene_file_to_dict(file_path)
+  seqrecord = snapgene_file_to_seqrecord(file_path)
 
 Installation
 ------------

--- a/snapgene_reader/snapgene_reader.py
+++ b/snapgene_reader/snapgene_reader.py
@@ -233,7 +233,6 @@ def snapgene_file_to_seqrecord(filepath=None, fileobject=None):
                     end=feature["end"],
                     strand=strand_dict[feature["strand"]],
                 ),
-                strand=strand_dict[feature["strand"]],
                 type=feature["type"],
                 qualifiers=feature["qualifiers"],
             )


### PR DESCRIPTION
Issue:
The script fails with a TypeError upon calling the snapgene_file_to_seqrecord function. The error message is: TypeError: __init__() got an unexpected keyword argument 'strand'. This occurs because the 'strand' information is being directly passed to the SeqFeature constructor.

Proposed solution:
I have modified the snapgene_file_to_seqrecord function to correctly include the strand information within the FeatureLocation object, rather than as a direct argument to the SeqFeature constructor. I have done so by deleting the line: 

```
strand=strand_dict[feature["strand"]]
```

This resolves the TypeError.

images showing the issue and its resolution:

Error:

<img width="1280" alt="Screenshot 2024-01-21 at 8 26 47 PM" src="https://github.com/Edinburgh-Genome-Foundry/SnapGeneReader/assets/59437395/37aa4880-d54d-4462-9bb7-fa87aba3cbf4">

Result after implementing the proposed solution:

<img width="1280" alt="Screenshot 2024-01-21 at 8 25 24 PM" src="https://github.com/Edinburgh-Genome-Foundry/SnapGeneReader/assets/59437395/8cbd7a62-918b-42e1-bdbc-ca2444482424">


